### PR TITLE
fixed sed syntax error which was causing an empty group to be selected

### DIFF
--- a/centrifuge-download
+++ b/centrifuge-download
@@ -394,7 +394,7 @@ for DOMAIN in $DOMAINS; do
         tr '\n' '\0' | xargs -0 -n1 -P $N_PROC bash -c 'download_n_process_nofail "$@"' _ | count $N_EXPECTED
 
     else
-      cut -f "$TAXID_FIELD,$FTP_PATH_FIELD" "$ASSEMBLY_SUMMARY_FILE" | sed 's#\([^/]*\)$#\1/\1_genomic.fna.gz#' |\
+      cut -f "$TAXID_FIELD,$FTP_PATH_FIELD" "$ASSEMBLY_SUMMARY_FILE" | sed 's#\([^/]*\)/\?$#\1/\1_genomic.fna.gz#' |\
          tr '\n' '\0' | xargs -0 -n1 -P $N_PROC bash -c 'download_n_process_nofail "$@"' _ | count $N_EXPECTED
     fi
     echo >&2


### PR DESCRIPTION
This pull request fixes a bug where the "sed" statement incorrectly captured an empty group due to trailing slashes in the "ftp_path" column values. The regex has been updated to account for the trailing slashes, ensuring that the intended string is consistently extracted regardless of the path's termination. This adjustment prevents empty data from propagating through the pipeline.