### PR TITLE
fix sed syntax error and standardize variable usage

### DIFF
--- a/centrifuge-download
+++ b/centrifuge-download
@@ -390,7 +390,7 @@ for DOMAIN in $DOMAINS; do
       #   tr '\n' '\0' | xargs -0 -n1 -P $N_PROC bash -c 'download_n_process_nofail "$@"' _ | count $N_EXPECTED
       cut -f "$TAXID_FIELD,$FTP_PATH_FIELD,$FTP_PATH_FIELD2" "$ASSEMBLY_SUMMARY_FILE" | \
         awk -F "\t" '{if ($2~/ftp/) print $1"\t"$2; if ($3~/ftp/) print $1"\t"$3}' | \
-        sed 's#\([^/]*\)/\?$#\1/\1_genomic.fna.gz#' |\
+        sed 's#\([^/]*\)$#\1/\1_genomic.fna.gz#' |\
         tr '\n' '\0' | xargs -0 -n1 -P $N_PROC bash -c 'download_n_process_nofail "$@"' _ | count $N_EXPECTED
 
     else

--- a/centrifuge-download
+++ b/centrifuge-download
@@ -390,7 +390,7 @@ for DOMAIN in $DOMAINS; do
       #   tr '\n' '\0' | xargs -0 -n1 -P $N_PROC bash -c 'download_n_process_nofail "$@"' _ | count $N_EXPECTED
       cut -f "$TAXID_FIELD,$FTP_PATH_FIELD,$FTP_PATH_FIELD2" "$ASSEMBLY_SUMMARY_FILE" | \
         awk -F "\t" '{if ($2~/ftp/) print $1"\t"$2; if ($3~/ftp/) print $1"\t"$3}' | \
-        sed 's#\([^/]*\)$#\1/\1_genomic.fna.gz#' |\
+        sed 's#\([^/]*\)/\?$#\1/\1_genomic.fna.gz#' |\
         tr '\n' '\0' | xargs -0 -n1 -P $N_PROC bash -c 'download_n_process_nofail "$@"' _ | count $N_EXPECTED
 
     else

--- a/centrifuge-download
+++ b/centrifuge-download
@@ -40,14 +40,14 @@ function download_n_process() {
             $DL_CMD "$FILEPATH" "$LIBDIR/$DOMAIN/$NAME.gz" || \
             { printf "\nError downloading $FILEPATH!\n" >&2 && exit 1; }
         else
-            $DL_CMD "$LIBDIR/$DOMAIN/$NAME.gz" "$FILEPATH" || \
-            $DL_CMD "$LIBDIR/$DOMAIN/$NAME.gz" "$FILEPATH" || \
-            $DL_CMD "$LIBDIR/$DOMAIN/$NAME.gz" "$FILEPATH" || \
+            $DL_CMD "$GZIPPED_FILE" "$FILEPATH" || \
+            $DL_CMD "$GZIPPED_FILE" "$FILEPATH" || \
+            $DL_CMD "$GZIPPED_FILE" "$FILEPATH" || \
 	    { printf "\nError downloading $FILEPATH!\n" >&2 && exit 1; }
         fi
     
-        [[ -s "$LIBDIR/$DOMAIN/$NAME.gz" ]] || return;
-        gunzip -f "$LIBDIR/$DOMAIN/$NAME.gz" ||{ printf "\nError gunzipping $LIBDIR/$DOMAIN/$NAME.gz [ downloaded from $FILEPATH ]!\n" >&2 &&  exit 255; }
+        [[ -s "$GZIPPED_FILE" ]] || return;
+        gunzip -f "$GZIPPED_FILE" ||{ printf "\nError gunzipping $LIBDIR/$DOMAIN/$NAME.gz [ downloaded from $FILEPATH ]!\n" >&2 &&  exit 255; }
     
         
         if [[ "$CHANGE_HEADER" == "1" ]]; then


### PR DESCRIPTION
fixes a syntax error in a sed command that was resulting in an invalid empty group selection. Additionally, it improves code readability by replacing "$LIBDIR/$DOMAIN/$NAME.gz" with the pre-defined "$GZIPPED_FILE" variable.